### PR TITLE
Cras Praça Céu adicionado

### DIFF
--- a/src/components/BairroCras.tsx
+++ b/src/components/BairroCras.tsx
@@ -10,10 +10,8 @@ export const BairroCras: Bairro[] = [
       'CODIN',
       'JARDIM BOA VISTA',
       'LAGOA DAS PEDRAS',
-      'NOVO ELDORADO',
       'PARQUE ELDORADO',
       'PARQUE JARDIM AEROPORTO',
-      'PARQUE JARDIM CEASA',
       'PARQUE SANTOS DUMONT',
       'PARQUE SÃO SILVESTRE',
       'TERRA PROMETIDA',
@@ -25,7 +23,6 @@ export const BairroCras: Bairro[] = [
   {
     cras: 'Custodópolis',
     bairro: [
-      'PARQUE BANDEIRANTES',
       'PARQUE BARAO DO RIO BRANCO',
       'PARQUE BONSUCESSO',
       'PARQUE CUSTODOPOLIS',
@@ -34,7 +31,6 @@ export const BairroCras: Bairro[] = [
       'PARQUE SANTA CLARA',
       'PARQUE SANTA ROSA',
       'PARQUE SÃO DOMINGOS',
-      'RESIDENCIAL PLANICIE',
       'COND SANTA ROSA',
       'COND SANTA ROSA 2',
       'COND. DOS NOGUEIRAS',
@@ -353,6 +349,16 @@ export const BairroCras: Bairro[] = [
       'TAPERA',
       'URURAI',
       'VIANA',
+    ],
+  },
+  {
+    cras: 'Praça Céu',
+    bairro: [
+      'JARDIM RESIDENCIAL PLANICIE',
+      'NOVO ELDORADO',
+      'PARQUE BANDEIRANTES',
+      'PARQUE JARDIM CEASA',
+      'PARQUE SANTA ROSA (CASINHAS NOLITA)',
     ],
   },
 ];

--- a/src/interface/User.ts
+++ b/src/interface/User.ts
@@ -30,6 +30,7 @@ export enum Cras {
   'Farol',
   'Jockey',
   'Ururaí',
+  'Praça Céu',
 }
 
 export interface IUserModel {
@@ -132,6 +133,7 @@ export enum Bairros {
   'JARDIM MARIA DE QUEIROZ',
   'JARDIM PARAISO DE TOCOS',
   'JARDIM PRIMAVERA',
+  'JARDIM RESIDENCIAL PLANICIE',
   'JOAO MARIA',
   'JOCKEY CLUB',
   'JOCKEY I',
@@ -223,6 +225,7 @@ export enum Bairros {
   'PARQUE SANTA CLARA',
   'PARQUE SANTA HELENA',
   'PARQUE SANTA ROSA',
+  'PARQUE SANTA ROSA (CASINHAS NOLITA)',
   'PARQUE SANTO AMARO',
   'PARQUE SANTO ANTONIO',
   'PARQUE SÃO BENEDITO',
@@ -263,7 +266,6 @@ export enum Bairros {
   'RADIO VELHO',
   'RES. VIVENDAS DA PENHA I',
   'RES. VIVENDAS DA PENHA II',
-  'RESIDENCIAL PLANICIE',
   'RETIRO',
   'RIBEIRO DO AMARO',
   'SABAO',


### PR DESCRIPTION
Cras Praça Céu adicionado juntamente com seus devidos bairros. Bairros adicionados ao Cras Praça Céu removidos de seus antigos Cras